### PR TITLE
Win32 build fixes

### DIFF
--- a/VapourSynth/meson.build
+++ b/VapourSynth/meson.build
@@ -54,6 +54,9 @@ endif
 
 if host_machine.system() == 'windows'
   add_project_arguments('-D__USE_MINGW_ANSI_STDIO', language : 'c')
+  if host_machine.cpu_family() == 'x86'
+    add_global_link_arguments('-Wl,--add-stdcall-alias', language : 'c')
+  endif
 endif
 
 shared_module('vslsmashsource', sources,

--- a/VapourSynth/meson.build
+++ b/VapourSynth/meson.build
@@ -55,6 +55,8 @@ endif
 if host_machine.system() == 'windows'
   add_project_arguments('-D__USE_MINGW_ANSI_STDIO', language : 'c')
   if host_machine.cpu_family() == 'x86'
+    add_project_arguments('-static-libgcc', language : 'c')
+    add_global_link_arguments('-static-libgcc', language : 'c')
     add_global_link_arguments('-Wl,--add-stdcall-alias', language : 'c')
   endif
 endif


### PR DESCRIPTION
32 bit windows VS plugin built with meson build script was not correctly loaded due to incorrect entry function name.
VS expect either `VapourSynthPluginInit` or `_VapourSynthPluginInit@12`, but libvslsmashsource.dll was exporting `VapourSynthPluginInit@12`.
Simply adding -Wl.--add-stdcall-alias fixes this issue.