### PR TITLE
common: do not crash when opening remote files

### DIFF
--- a/common/lwindex.c
+++ b/common/lwindex.c
@@ -1988,9 +1988,10 @@ static void cleanup_index_helpers( lwindex_indexer_t *indexer, AVFormatContext *
 
 static uint64_t xxhash_file( const char *file_path, int64_t file_size )
 {
+    FILE *fp = lw_fopen( file_path, "rb" );
+    if( !fp ) return 0;
     uint8_t *file_buffer = (uint8_t *)lw_malloc_zero( 1 << 21 );
     const size_t read_len = 1 << 20;
-    FILE *fp = lw_fopen( file_path, "rb" );
     size_t buffer_len = fread( file_buffer, 1, read_len, fp );
     if( file_size > (1 << 21) )
     {


### PR DESCRIPTION
If we set cachefile to a local file (or cache=0), LWLibavSource is perfectly
capable to open remote files (e.g. given a URL). xxhash_file was assuming all
files are local and did not check the result value of fopen, and this change
fixes it.

Signed-off-by: akarin <i@akarin.info>